### PR TITLE
Visualization tools for Rviz

### DIFF
--- a/ros/src/styx_visualization/CMakeLists.txt
+++ b/ros/src/styx_visualization/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(styx_visualization)
+
+find_package(catkin)
+
+catkin_package()
+
+catkin_install_python(PROGRAMS scripts/lane_to_marker
+                               scripts/traffic_light_to_marker
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/ros/src/styx_visualization/config.rviz
+++ b/ros/src/styx_visualization/config.rviz
@@ -1,0 +1,141 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /TF1/Frames1
+        - /RobotModel1/Status1
+        - /MarkerArray1
+        - /MarkerArray1/Namespaces1
+      Splitter Ratio: 0.5
+    Tree Height: 786
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        base_link:
+          Value: true
+        world:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        world:
+          base_link:
+            {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: visualization_marker_array
+      Name: MarkerArray
+      Namespaces:
+        lane: true
+      Queue Size: 100
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/XYOrbit
+      Distance: 82.172
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.06
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Name: Current View
+      Near Clip Distance: 0.01
+      Pitch: 0.555396
+      Target Frame: base_link
+      Value: XYOrbit (rviz)
+      Yaw: 3.42177
+    Saved: ~
+Window Geometry:
+  Camera:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 1020
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000355fc0200000009fb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afc0000004300000355000000df00fffffffa000000010100000002fb0000000c00430061006d0065007200610000000000ffffffff0000005e0000005efb000000100044006900730070006c00610079007301000000000000016a0000016a00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006500000001f0000000da0000000000000000fb0000000a0049006d0061006700650000000288000001100000000000000000000000010000010f00000355fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fc0000004300000355000000b800fffffffa000000010100000002fb0000001200530065006c0065006300740069006f006e0000000000ffffffff0000006700fffffffb0000000a00560069006500770073010000066f0000010f0000010f00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b20000000000000000000000020000077e000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000077e0000003efc0100000002fb0000000800540069006d006501000000000000077e0000022a00fffffffb0000000800540069006d00650100000000000004500000000000000000000004f90000035500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1918
+  X: -9
+  Y: -8

--- a/ros/src/styx_visualization/launch/visualization.launch
+++ b/ros/src/styx_visualization/launch/visualization.launch
@@ -8,6 +8,8 @@
     <remap from="lane" to="/base_waypoints"/>
     <param name="color" value="green"/>
     <param name="marker_ns" value="base"/>
+    <!-- This message is the same every time, so unsubscribe after running once -->
+    <param name="once" value="true"/>
   </node>
 
   <node name="final_lane_visualizer"

--- a/ros/src/styx_visualization/launch/visualization.launch
+++ b/ros/src/styx_visualization/launch/visualization.launch
@@ -23,6 +23,11 @@
     <param name="color" value="red"/>
     <param name="marker_ns" value="traffic"/>
   </node>
+  
+  <node name="traffic_light_visualizer"
+        pkg="styx_visualization" type="traffic_light_to_marker">
+    <remap from="traffic_lights" to="/vehicle/traffic_lights"/>
+  </node>
 
   <node name="$(anon rviz)" pkg="rviz" type="rviz"
         args="-d $(find styx_visualization)/config.rviz"/>

--- a/ros/src/styx_visualization/launch/visualization.launch
+++ b/ros/src/styx_visualization/launch/visualization.launch
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="robot_description"
+         command="$(find xacro)/xacro '$(find dbw_mkz_description)/urdf/mkz.urdf.xacro'" />
+
+  <node name="base_lane_visualizer"
+        pkg="styx_visualization" type="lane_to_marker">
+    <remap from="lane" to="/base_waypoints"/>
+    <param name="color" value="green"/>
+    <param name="marker_ns" value="base"/>
+  </node>
+
+  <node name="final_lane_visualizer"
+        pkg="styx_visualization" type="lane_to_marker">
+    <remap from="lane" to="/final_waypoints"/>
+    <param name="color" value="blue"/>
+    <param name="marker_ns" value="final"/>
+  </node>
+
+  <node name="traffic_lane_visualizer"
+        pkg="styx_visualization" type="lane_to_marker">
+    <remap from="lane" to="/traffic_waypoints"/>
+    <param name="color" value="red"/>
+    <param name="marker_ns" value="traffic"/>
+  </node>
+
+  <node name="$(anon rviz)" pkg="rviz" type="rviz"
+        args="-d $(find styx_visualization)/config.rviz"/>
+</launch>

--- a/ros/src/styx_visualization/package.xml
+++ b/ros/src/styx_visualization/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>styx_visualization</name>
+  <version>0.0.0</version>
+  <description>
+    Nodes to help visualize messages from the Udacity styx simulator.
+  </description>
+  <maintainer email="evenator@gmail.com">Ed Venator</maintainer>
+  <license>BSD</license>
+  <url>https://github.com/evenator/CarND-Capstone</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>styx_msgs</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+</package>

--- a/ros/src/styx_visualization/package.xml
+++ b/ros/src/styx_visualization/package.xml
@@ -10,7 +10,11 @@
   <url>https://github.com/evenator/CarND-Capstone</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <exec_depend>dbw_mkz_description</exec_depend>
   <exec_depend>rospy</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
   <exec_depend>styx_msgs</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
+  <exec_depend>xacro</exec_depend>
 </package>

--- a/ros/src/styx_visualization/scripts/lane_to_marker
+++ b/ros/src/styx_visualization/scripts/lane_to_marker
@@ -10,7 +10,7 @@ def lane_to_marker_array(lane, color, ns='lane'):
     # Create a linestrip marker
     lines = Marker()
     lines.header = lane.header
-    lines.ns = 'lane'
+    lines.ns = ns
     lines.id = 0
     lines.type = Marker.LINE_STRIP
     lines.action = Marker.ADD

--- a/ros/src/styx_visualization/scripts/lane_to_marker
+++ b/ros/src/styx_visualization/scripts/lane_to_marker
@@ -1,0 +1,54 @@
+#! /usr/bin/env python
+
+from copy import deepcopy
+import rospy
+from std_msgs.msg import ColorRGBA
+from styx_msgs.msg import Lane
+from visualization_msgs.msg import Marker, MarkerArray
+
+def lane_to_marker_array(lane, color, ns='lane'):
+    # Create a linestrip marker
+    lines = Marker()
+    lines.header = lane.header
+    lines.ns = 'lane'
+    lines.id = 0
+    lines.type = Marker.LINE_STRIP
+    lines.action = Marker.ADD
+    lines.pose.orientation.w = 1.0
+    lines.scale.x = 0.1
+    lines.points = [p.pose.pose.position for p in lane.waypoints]
+    lines.color = color
+    
+    # Create a points marker for the vertices
+    points = deepcopy(lines)
+    points.id = 1
+    points.type = Marker.SPHERE_LIST
+    points.scale.x = 0.3
+    points.scale.y = 0.3
+    points.scale.z = 0.3
+    
+    # Put the markers in an array and return it
+    marker_array = MarkerArray()
+    marker_array.markers.append(lines)
+    marker_array.markers.append(points)
+    return marker_array
+    
+# Define some colors we can use
+colors = {'red':   ColorRGBA(r=1.0, g=0.0, b=0.0, a=1.0),
+          'green': ColorRGBA(r=0.0, g=1.0, b=0.0, a=1.0),
+          'blue':  ColorRGBA(r=0.0, g=0.0, b=1.0, a=1.0)
+}
+
+if __name__ == "__main__":
+    rospy.init_node('lane_to_marker')
+    marker_pub = rospy.Publisher('visualization_marker_array', MarkerArray, queue_size=2)
+    ns = rospy.get_param('~marker_ns', 'lane')
+    color_string = rospy.get_param('~color', 'red')
+    color = colors[color_string.lower()]
+    
+    def handle_lane_msg(lane_msg):
+        marker_pub.publish(lane_to_marker_array(lane_msg, color, ns))
+    
+    lane_sub = rospy.Subscriber('lane', Lane, handle_lane_msg, queue_size=2)
+
+    rospy.spin()

--- a/ros/src/styx_visualization/scripts/lane_to_marker
+++ b/ros/src/styx_visualization/scripts/lane_to_marker
@@ -41,14 +41,20 @@ colors = {'red':   ColorRGBA(r=1.0, g=0.0, b=0.0, a=1.0),
 
 if __name__ == "__main__":
     rospy.init_node('lane_to_marker')
-    marker_pub = rospy.Publisher('visualization_marker_array', MarkerArray, queue_size=2)
+    marker_pub = rospy.Publisher('visualization_marker_array',
+                                 MarkerArray,
+                                 queue_size=2,
+                                 latch=True)
     ns = rospy.get_param('~marker_ns', 'lane')
     color_string = rospy.get_param('~color', 'red')
+    once = rospy.get_param('~once', False)
     color = colors[color_string.lower()]
     
     def handle_lane_msg(lane_msg):
         marker_pub.publish(lane_to_marker_array(lane_msg, color, ns))
-    
+        if once:
+            lane_sub.unregister()
+    global lane_sub
     lane_sub = rospy.Subscriber('lane', Lane, handle_lane_msg, queue_size=2)
 
     rospy.spin()

--- a/ros/src/styx_visualization/scripts/traffic_light_to_marker
+++ b/ros/src/styx_visualization/scripts/traffic_light_to_marker
@@ -1,0 +1,46 @@
+#! /usr/bin/env python
+
+import rospy
+from std_msgs.msg import ColorRGBA
+from styx_msgs.msg import TrafficLightArray, TrafficLight
+from visualization_msgs.msg import Marker, MarkerArray
+
+colors = {TrafficLight.UNKNOWN: ColorRGBA(r=0.5, g=0.5, b=0.5, a=1.0),
+          TrafficLight.GREEN:   ColorRGBA(r=0.0, g=1.0, b=0.0, a=1.0),
+          TrafficLight.YELLOW:  ColorRGBA(r=1.0, g=1.0, b=0.0, a=1.0),
+          TrafficLight.RED:     ColorRGBA(r=1.0, g=0.0, b=0.0, a=1.0)
+}
+
+def traffic_light_to_marker(light, id=0):
+    marker = Marker()
+    marker.header = light.header
+    marker.ns = 'traffic_lights'
+    marker.id = id
+    marker.type = Marker.CYLINDER
+    marker.action = Marker.ADD
+    marker.pose = light.pose.pose
+    marker.scale.x = 0.3
+    marker.scale.y = 0.3
+    marker.scale.z = 0.5
+    marker.color = colors[light.state]
+    return marker
+
+def traffic_light_array_to_marker_array(light_array):
+    marker_array = MarkerArray()
+    marker_array.markers = [traffic_light_to_marker(light, id)
+                                for id, light in enumerate(light_array.lights)]
+    return marker_array
+
+if __name__ == "__main__":
+    rospy.init_node('traffic_light_to_marker')
+    marker_pub = rospy.Publisher('visualization_marker_array', MarkerArray, queue_size=2)
+
+    def handle_traffic_light_msg(light_array):
+        marker_pub.publish(traffic_light_array_to_marker_array(light_array))
+    
+    traffic_light_sub = rospy.Subscriber('traffic_lights',
+                                         TrafficLightArray,
+                                         handle_traffic_light_msg,
+                                         queue_size=2)
+
+    rospy.spin()


### PR DESCRIPTION
Summary:

[rviz](http://wiki.ros.org/rviz) is a 3D visualization tool for ROS. It has plugins that let you view several common message types. However, because the Udacity implemented custom `Lane` and `TrafficLight` messages, we can't use rviz. I made some nodes that publish `visualization_msgs/MarkerArrays` to visualize the lane waypoints and traffic lights.

![rviz_screenshot_2017_09_16-10_23_44](https://user-images.githubusercontent.com/567836/30512988-40eb9f78-9ac9-11e7-81e8-0c50cb263fb7.png)

![rviz_screenshot_2017_09_16-10_24_02](https://user-images.githubusercontent.com/567836/30512989-42a58180-9ac9-11e7-837f-458d7044f6e3.png)


To use:

1. Start ROS code and simulator as normal with `roslaunch launch/styx.launch`
2. Start rviz and visualization helper nodes with `roslaunch styx_visualization visualization.launch`

In rviz, the car is shown as a 3D model, the base waypoints are shown in green, and the final waypoints are shown in blue. Traffic lights appear as colored cylinders (red, yellow, green, or grey if unknown).