### PR TITLE
Change wraparound code to eliminate IndexError

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -71,14 +71,7 @@ class WaypointUpdater(object):
         # Collecting the waypoints ahead of the car. 
         # Wrap around when we reach the end.
         for i in range(LOOKAHEAD_WPS):
-            if (i + start_idx > (len(self.curr_waypoints) - 1)) and (not reset):
-                start_idx = 0
-                idx = 0
-                reset = 1
-            elif reset:
-                idx += 1
-            else:
-                idx = i + start_idx
+            idx = (start_idx + i) % len(self.curr_waypoints)
             lane.waypoints.append(self.curr_waypoints[idx])
          
         #rospy.logerr('Start idx: %s', start_idx)


### PR DESCRIPTION
The wraparound logic in the `waypoints_cb()` was not resilient to all wraparound conditions and would sometimes crash with an `IndexError`. I changed the logic to fix the problem and tested with the bag file that caused the crash and with the simulator. The `IndexError` no longer occurs with the bag, and there are no regressions with the simulator.

@lukscasanova, since this is your branch, I'll let you approve this merge.