### PR TITLE
Twist Controller Acceleration Limit

### DIFF
--- a/ros/src/twist_controller/scripts/dbw_node
+++ b/ros/src/twist_controller/scripts/dbw_node
@@ -44,7 +44,7 @@ class DBWNode(object):
 
         Stores DBW enabled state for later use.
         """
-        self.dbw_enabled = dbw_enabled
+        self.dbw_enabled = dbw_enabled.data
 
     def __init__(self):
         """

--- a/ros/src/twist_controller/scripts/dbw_node
+++ b/ros/src/twist_controller/scripts/dbw_node
@@ -157,5 +157,9 @@ class DBWNode(object):
 
 if __name__ == '__main__':
     rospy.init_node('dbw_node')
-    dbw = DBWNode()
-    dbw.loop()
+    while True:
+        try:
+            dbw = DBWNode()
+            dbw.loop()
+        except rospy.exceptions.ROSTimeMovedBackwardsException:
+            pass

--- a/ros/src/twist_controller/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/src/twist_controller/pid.py
@@ -21,7 +21,10 @@ class PID(object):
         self.last_int_val = self.int_val
 
         integral = self.int_val + error * sample_time;
-        derivative = (error - self.last_error) / sample_time;
+        if sample_time != 0.0:
+            derivative = (error - self.last_error) / sample_time;
+        else:
+            derivative = 0.0
 
         y = self.kp * error + self.ki * self.int_val + self.kd * derivative;
         val = max(self.min, min(y, self.max))

--- a/ros/src/twist_controller/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/src/twist_controller/twist_controller.py
@@ -63,7 +63,10 @@ class Controller(object):
         self.cur_acc = self.accel_filter.filt(raw_acc)
         self.last_cur_lin_vel = cur_lin_vel
 
-        steer_error = (cmd_ang_vel - cur_ang_vel)/delta_t
+        if delta_t != 0.0:
+            steer_error = (cmd_ang_vel - cur_ang_vel)/delta_t
+        else:
+            steer_error = 0.0
 
         if(abs(cmd_lin_vel)<1.):
             steering = 0

--- a/ros/src/twist_controller/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/src/twist_controller/twist_controller.py
@@ -50,15 +50,7 @@ class Controller(object):
             self.reset()
             return (0, 0, 0)
 
-        if delta_t != 0.0:
-            steer_error = (cmd_ang_vel - cur_ang_vel)/delta_t
-        else:
-            steer_error = 0.0
-
-        if(abs(cmd_lin_vel)<1.):
-            steering = 0
-        else:
-            steering = 0.8*atan(self.wheel_base * cmd_ang_vel / cmd_lin_vel) * self.steer_ratio
+        steering = self.calculate_steering(cmd_ang_vel, cmd_lin_vel)
 
         cmd_acc = self.speed_pid.step(vel_error, delta_t)
 
@@ -80,6 +72,14 @@ class Controller(object):
             brake = 0.
 
         return throttle, brake, steering
+
+    def calculate_steering(self, cmd_ang_vel, cmd_lin_vel):
+        # TODO: This threshold can probably be closer to 0
+        if abs(cmd_lin_vel) < 1.0:
+            return 0.0
+        else:
+            # TODO: Remove the magic number here
+            return 0.8*atan(self.wheel_base * cmd_ang_vel / cmd_lin_vel) * self.steer_ratio
 
     def reset(self):
         self.last_cur_lin_vel = 0

--- a/ros/src/twist_controller/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/src/twist_controller/twist_controller.py
@@ -108,6 +108,7 @@ class Controller(object):
         return force * self.wheel_radius
 
     def reset(self):
-        self.last_cur_lin_vel = 0
+        self.last_cur_lin_vel = 0.0
+        self.last_cmd_vel = 0.0
         self.speed_pid.reset()
         self.throttle_pid.reset()

--- a/ros/src/twist_controller/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/src/twist_controller/twist_controller.py
@@ -61,7 +61,10 @@ class Controller(object):
 
         # Acceleration Measurement Calculation
         vel_error = cmd_lin_vel - cur_lin_vel
-        raw_acc = (cur_lin_vel - self.last_cur_lin_vel)/delta_t
+        if delta_t != 0.0:
+            raw_acc = (cur_lin_vel - self.last_cur_lin_vel)/delta_t
+        else:
+            raw_acc = 0
         cur_acc = self.accel_filter.filt(raw_acc)
         self.last_cur_lin_vel = cur_lin_vel
 

--- a/ros/src/twist_controller/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/src/twist_controller/twist_controller.py
@@ -1,6 +1,7 @@
 """Throttle, brake, and steering control."""
 from math import atan
-from rospy import loginfo
+from rospy import loginfo, Publisher
+from std_msgs.msg import Float32
 from .lowpass import LowPassFilter
 from .pid import PID
 
@@ -22,6 +23,7 @@ class Controller(object):
         Set up gains and initialize internal state; initialize PID controllers.
         """
         self.last_cur_lin_vel = 0
+        self.last_cmd_vel = 0
         self.accel_limit = accel_limit
         self.decel_limit = decel_limit
         self.vehicle_mass = vehicle_mass
@@ -33,6 +35,10 @@ class Controller(object):
         self.accel_filter = LowPassFilter(0.2, 1./rate)
         self.throttle_pid = PID(kp_throttle, ki_throttle, 0.0, 0, 1.)
 
+        self.debug_cmd_a = Publisher('~debug_cmd_acc', Float32, queue_size=2)
+        self.debug_cmd_vel = Publisher('~debug_cmd_vel', Float32, queue_size=2)
+        self.debug_cur_a = Publisher('~debug_cur_acc', Float32, queue_size=2)
+
     def control(self, cmd_lin_vel, cmd_ang_vel, cur_lin_vel, cur_ang_vel, delta_t, dbw_enabled):
         """
         Control update.
@@ -40,29 +46,40 @@ class Controller(object):
         This function should be called at the rate given in the constructor.
         Returns a tuple of (throttle, brake, steering)
         """
+        # Steering
+        if abs(cmd_lin_vel) > 0.1:
+            curvature = cmd_ang_vel / cmd_lin_vel
+        else:
+            curvature = cmd_ang_vel / 0.1
+        steering = self.calculate_steering(curvature)
 
+        # Acceleration limiting (velocity ramp)
+        min_vel = self.last_cmd_vel + self.decel_limit * delta_t
+        max_vel = self.last_cmd_vel + self.accel_limit * delta_t
+        cmd_lin_vel = max(min_vel, min(cmd_lin_vel, max_vel))
+        self.last_cmd_vel = cmd_lin_vel
+
+        # Acceleration Measurement Calculation
         vel_error = cmd_lin_vel - cur_lin_vel
-        raw_acc = cur_lin_vel - self.last_cur_lin_vel
+        raw_acc = (cur_lin_vel - self.last_cur_lin_vel)/delta_t
         cur_acc = self.accel_filter.filt(raw_acc)
         self.last_cur_lin_vel = cur_lin_vel
 
+        # If DBW not enabled, reset and return
         if not dbw_enabled:
             self.reset()
             return (0, 0, 0)
 
-        steering = self.calculate_steering(cmd_ang_vel, cmd_lin_vel)
-
+        # Speed PID to get commanded acceleration
         cmd_acc = self.speed_pid.step(vel_error, delta_t)
 
-        if cmd_acc > self.accel_limit:
-            cmd_acc = self.accel_limit
-        elif cmd_acc < self.decel_limit:
-            cmd_acc = self.decel_limit
+        # Acceleration limiting (commanded acceleration)
+        cmd_acc = max(self.decel_limit, min(cmd_acc, self.accel_limit))
 
-        throttle_error = (cmd_acc - cur_acc)
-
-        brake = -cmd_acc*self.vehicle_mass*self.wheel_radius
+        # Throttle and brake calculations
+        throttle_error = cmd_acc - cur_acc
         throttle = self.throttle_pid.step(throttle_error, delta_t)
+        brake = self.calculate_brake(cmd_acc)
 
         if cmd_acc < 0:
             if brake < self.brake_deadband:
@@ -71,15 +88,21 @@ class Controller(object):
         else:
             brake = 0.
 
+        self.debug_cmd_vel.publish(Float32(data=cmd_lin_vel))
+        self.debug_cmd_a.publish(Float32(data=cmd_acc))
+        self.debug_cur_a.publish(Float32(data=cur_acc))
         return throttle, brake, steering
 
-    def calculate_steering(self, cmd_ang_vel, cmd_lin_vel):
-        # TODO: This threshold can probably be closer to 0
-        if abs(cmd_lin_vel) < 1.0:
-            return 0.0
-        else:
-            # TODO: Remove the magic number here
-            return 0.8*atan(self.wheel_base * cmd_ang_vel / cmd_lin_vel) * self.steer_ratio
+    def calculate_steering(self, curvature):
+        # TODO: Remove this magic number
+        return 0.8*atan(self.wheel_base * curvature) * self.steer_ratio
+
+    def calculate_brake(self, cmd_acc):
+        '''
+        Calculate brake torque to achieve desired deceleration
+        '''
+        force = -cmd_acc * self.vehicle_mass
+        return force * self.wheel_radius
 
     def reset(self):
         self.last_cur_lin_vel = 0

--- a/ros/src/waypoint_updater/launch/waypoint_updater.launch
+++ b/ros/src/waypoint_updater/launch/waypoint_updater.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
     <node pkg="waypoint_updater" type="waypoint_updater.py" name="waypoint_updater" output="screen">
-    	<param name="use_ground_truth" value="true" />
-    	<param name="nb_stopping_wp" value="30" />
+        <param name="use_ground_truth" value="false" />
+        <param name="nb_stopping_wp" value="30" />
     </node>
 </launch>

--- a/ros/src/waypoint_updater/launch/waypoint_updater.launch
+++ b/ros/src/waypoint_updater/launch/waypoint_updater.launch
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="waypoint_updater" type="waypoint_updater.py" name="waypoint_updater" output="screen"/>
+    <node pkg="waypoint_updater" type="waypoint_updater.py" name="waypoint_updater" output="screen">
+    	<param name="use_ground_truth" value="true" />
+    	<param name="nb_stopping_wp" value="30" />
+    </node>
 </launch>

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -79,7 +79,7 @@ class WaypointUpdater(object):
         self.lane = Lane()
         self.last_lane = Lane()
 
-        self.traffic_lights = None
+        self.traffic_lights = []
 
         self.state = WaypointUpdater.ACCELERATING
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -164,9 +164,11 @@ class WaypointUpdater(object):
         self.traffic_light_wp_index = -1
         # Check if there is a traffic light on the lookahead path
         for light in self.traffic_lights:
+            if(light.state is not TrafficLight.RED):
+                continue
             index = self.closest_index(light)
             if index >= self.nb_stopping_wp-5:
-                self.traffic_light_wp_index = index
+                self.traffic_light_wp_index = index-self.nb_stopping_wp
                 return
 
     def step(self):
@@ -177,9 +179,13 @@ class WaypointUpdater(object):
             self.lane = self.keep_speed(self.lane, self.cruise_velocity)
             self.commanded_velocity = self.cruise_velocity
 
-        stop_index = self.traffic_light_wp_index - self.start_idx
-        if stop_index < 0:
-            stop_index += len(self.curr_waypoints)
+        if(self.use_ground_truth):
+            stop_index = self.traffic_light_wp_index
+        else:
+            stop_index = self.traffic_light_wp_index - self.start_idx
+            if stop_index < 0:
+                stop_index += len(self.curr_waypoints)
+        
         rospy.loginfo("Traffic light index: %d Stop index: %d",
                       self.traffic_light_wp_index,
                       stop_index)


### PR DESCRIPTION
This is a substantial refactoring of the dbw_node and twist_controller, but most of the changes are cosmetic. The functional changes are:

- Fix `dbw_enabled` logic so that the controller actually resets when the dbw is disabled (tested and confirmed on bags)
- Protect against dividing by zero in a couple of places. This only comes up during bag playback
- Apply a ramp constraint to the commanded velocity such that it cannot exceed the acceleration and deceleration limits. This should fix the rapid acceleration problem that came up in the review. (See below.)
- Add debug topics `debug_cmd_acc`, `debug_cmd_vel`, and `debug_cur_acc` to facilitate plotting and tuning
- Handle the ROSTimeMovedBackwards exception. This only comes up during bag playback.

The most significant change is the addition of the ramp constraint. You can see the effect in this plot.
![twist_controller](https://user-images.githubusercontent.com/567836/31526325-18848510-af94-11e7-8699-80a6e29907ed.png)
The red line is the commanded velocity. The bright blue line is the commanded linear velocity after applying the ramp constraint.
The  green line is the throttle from the bag, and the dark blue line is the velocity from the bag. The pink line is the throttle with the improved controller. Notice that it is considerably less than the throttle from the bag.